### PR TITLE
Fix lat/lon order and wiki link

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -44,7 +44,7 @@ const wiki = {
   'kaala-gomen': 'https://en.wikipedia.org/wiki/Kaala-Gomen',
   'koumac': 'https://en.wikipedia.org/wiki/Koumac',
   'poum': 'https://en.wikipedia.org/wiki/Poum',
-  'bélep': 'https://en.wikipedia.org/wiki/Bélep',
+  'belep': 'https://en.wikipedia.org/wiki/Belep',
   'ouégoa': 'https://en.wikipedia.org/wiki/Ouégoa',
   'pouébo': 'https://en.wikipedia.org/wiki/Pouébo',
   'hienghène': 'https://en.wikipedia.org/wiki/Hiengh%C3%A8ne',
@@ -192,7 +192,8 @@ async function locatePoint(lat, lon) {
   await loadCommuneLayer();
   if (!communeLayer) return;
   // Use leaflet‑pip to find all polygons containing the point.
-  const matches = leafletPip.pointInLayer([lat, lon], communeLayer, true);
+  // leaflet-pip expects [lon, lat] order for the coordinate array
+  const matches = leafletPip.pointInLayer([lon, lat], communeLayer, true);
   if (matches.length > 0) {
     const feature = matches[0].feature;
     // Remove previous highlight


### PR DESCRIPTION
## Summary
- correct order of lon/lat when using leaflet-pip
- fix Belep wikipedia url key

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_688890fbf90c832d982c11b23e12d804

## Summary by Sourcery

Fix coordinate ordering for spatial containment and correct the Belep Wikipedia mapping key

Bug Fixes:
- Use [lon, lat] order for leaflet-pip pointInLayer call to ensure proper polygon matching
- Update the wiki mapping key for Belep to align with its Wikipedia URL