### PR TITLE
Fix offline map with local tile and GeoJSON fallback

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,15 +22,20 @@ const OFFLINE_TILE =
 // if network access is blocked.
 async function createTileLayer() {
   try {
-    const resp = await fetch('https://tile.openstreetmap.org/0/0/0.png', { mode: 'no-cors' });
-    if (resp.ok || resp.type === 'opaque') {
+    const resp = await fetch('https://tile.openstreetmap.org/0/0/0.png', {
+      mode: 'no-cors',
+      signal: AbortSignal.timeout(5000) // 5-second timeout
+    });
+    // For 'no-cors', a successful network request results in an 'opaque' response.
+    if (resp.type === 'opaque') {
       return L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 19,
         attribution: '\u00A9 OpenStreetMap contributors'
       });
     }
+    console.warn(`Unexpected response from tile server: type ${resp.type}`);
   } catch (err) {
-    console.warn('Tile server unreachable:', err);
+    console.warn('Tile server unreachable, using offline tile:', err.message);
   }
   return L.tileLayer(OFFLINE_TILE, { maxZoom: 19, attribution: '' });
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -15,13 +15,29 @@
 const MAP_CENTER = [-21.5, 165.5];
 const MAP_ZOOM   = 8;
 const GEOJSON_URL = 'data/nc-communes.geojson';
+const OFFLINE_TILE =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wIAAgUBBu/q6QAAAABJRU5ErkJggg==';
+
+// Attempt to create a tile layer from OpenStreetMap. Fallback to a blank tile
+// if network access is blocked.
+async function createTileLayer() {
+  try {
+    const resp = await fetch('https://tile.openstreetmap.org/0/0/0.png', { mode: 'no-cors' });
+    if (resp.ok || resp.type === 'opaque') {
+      return L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '\u00A9 OpenStreetMap contributors'
+      });
+    }
+  } catch (err) {
+    console.warn('Tile server unreachable:', err);
+  }
+  return L.tileLayer(OFFLINE_TILE, { maxZoom: 19, attribution: '' });
+}
 
 // ---- Map ----
 const map = L.map('map', { zoomControl: true }).setView(MAP_CENTER, MAP_ZOOM);
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-  maxZoom: 19,
-  attribution: '\u00A9 OpenStreetMap contributors'
-}).addTo(map);
+createTileLayer().then(layer => layer.addTo(map));
 
 let communeLayer = null;
 let activeMarker = null;
@@ -57,9 +73,16 @@ function announce(msg) {
   if (status) status.textContent = msg;
 }
 // ---- Load GeoJSON ----
-fetch(GEOJSON_URL)
-  .then(r => r.json())
-  .then(fc => {
+function loadCommuneData() {
+  return fetch(GEOJSON_URL)
+    .then(r => r.json())
+    .catch(err => {
+      console.error('GeoJSON fetch failed:', err);
+      return (typeof COMMUNES_DATA !== 'undefined') ? COMMUNES_DATA : null;
+    });
+}
+
+loadCommuneData().then(fc => {
     if (!fc || !Array.isArray(fc.features)) {
       showToast('Failed to parse communes data.');
       return;

--- a/index.html
+++ b/index.html
@@ -86,6 +86,9 @@
   <!-- leaflet-pip for point-in-polygon -->
   <script src="libs/leaflet-pip/leaflet-pip.min.js"></script>
 
+  <!-- GeoJSON fallback data for offline use -->
+  <script src="assets/js/communes.js"></script>
+
   <!-- App JS -->
   <script defer src="assets/js/app.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
   <script src="libs/leaflet-pip/leaflet-pip.min.js"></script>
 
   <!-- GeoJSON fallback data for offline use -->
-  <script src="assets/js/communes.js"></script>
+  <script defer src="assets/js/communes.js"></script>
 
   <!-- App JS -->
   <script defer src="assets/js/app.js"></script>


### PR DESCRIPTION
## Summary
- load an offline tile if the external map tiles are unavailable
- load GeoJSON data from `communes.js` when the fetch fails
- include `communes.js` in the page so the fallback is available

## Testing
- `curl -I http://localhost:8000/index.html`
- `curl -I http://localhost:8000/assets/js/communes.js`
- `grep -n "GET /index.html" /tmp/server.log | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_6888c6b970d0832d9a3732f86eab7861

## Summary by Sourcery

Add offline support for map tiles and commune GeoJSON data by introducing fetch fallbacks to local resources

Enhancements:
- Add createTileLayer to attempt fetching OpenStreetMap tiles and fall back to a blank base64-encoded tile when unreachable
- Introduce loadCommuneData to fetch GeoJSON data and fall back to local COMMUNES_DATA from communes.js on fetch failure
- Include local communes.js in index.html to provide offline GeoJSON fallback