### PR TITLE
Add layer controls and point tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Leaflet-based web app to identify the **commune (municipality)** of New Caledonia for any coordinate.
 Enter `lat,lng` or search by name (accent-insensitive). Uses precise point-in-polygon via `leaflet-pip`.
+The app now includes a layer panel to toggle commune styling, switch base maps and add custom points.
 
 - **Live site:** https://rcesaret.github.io/nc-commune-locator/
 - **Tech:** Leaflet, leaflet-pip, vanilla JS
@@ -34,6 +35,7 @@ python -m http.server 8000
 * Enter coordinates as `-21.5, 165.5` (decimal degrees); the app returns the commune via point-in-polygon.
 * Or type a commune name (case/diacritic-insensitive) to zoom and popup the boundary.
 * Use the 🐌 button to toggle lazy loading of commune polygons.
+* Open the layer panel (left) to style commune borders/fill, switch basemaps and add custom points. Points can be exported as GeoJSON.
 
 ## Development Notes
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -175,6 +175,32 @@ html, body, #map {
   inset: 0;
 }
 
+/* Layer panel */
+.layer-panel {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 1000;
+  background: #ffffff;
+  padding: 8px 10px;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.15);
+  max-width: 200px;
+}
+.layer-panel.collapsed #layerContent {
+  display: none;
+}
+.layer-panel button#toggleLayerPanel {
+  float: right;
+  font-size: 14px;
+  margin-left: 4px;
+}
+.style-group {
+  display: flex;
+  gap: 4px;
+  margin: 4px 0;
+}
+
 /* Tooltip style override */
 .leaflet-tooltip.custom-tooltip {
   background: #ffffff;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -180,7 +180,7 @@ html, body, #map {
   position: absolute;
   top: 10px;
   left: 10px;
-  z-index: 1000;
+  z-index: 1001;
   background: #ffffff;
   padding: 8px 10px;
   border-radius: 8px;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -524,11 +524,15 @@ map.on('click', (e) => {
     addPointBtn.classList.remove('active');
     const label = prompt('Point label (optional)', '') || '';
     const color = prompt('Marker color', '#ff0000') || '#ff0000';
-    const opacity = parseFloat(prompt('Opacity 0-1', '0.8'));
+    let opacity = parseFloat(prompt('Opacity 0-1', '0.8'));
+    if (isNaN(opacity) || opacity < 0 || opacity > 1) {
+      alert('Invalid opacity value. Using default 0.8.');
+      opacity = 0.8;
+    }
     const marker = L.circleMarker(e.latlng, {
       color,
       fillColor: color,
-      fillOpacity: isNaN(opacity) ? 0.8 : opacity,
+      fillOpacity: opacity,
       radius: 6
     }).addTo(pointsLayer);
     marker.bindPopup(label || `${e.latlng.lat.toFixed(5)}, ${e.latlng.lng.toFixed(5)}`);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -541,7 +541,7 @@ map.on('click', (e) => {
       try {
         const hits = leafletPip.pointInLayer([e.latlng.lng, e.latlng.lat], communeLayer, true);
         if (hits.length) communeName = hits[0].feature?.properties?.name || null;
-      } catch {}
+      } catch (err) { console.error('Point-in-polygon check failed:', err); }
     }
     points.push({
       type: 'Feature',

--- a/index.html
+++ b/index.html
@@ -25,6 +25,35 @@
     This application requires JavaScript to run. Please enable JavaScript and reload the page.
   </div>
 
+  <!-- Layer & style panel -->
+  <div id="layerPanel" class="layer-panel" aria-label="Layer controls">
+    <button id="toggleLayerPanel" type="button" title="Collapse layer panel">&laquo;</button>
+    <div id="layerContent">
+      <h3>Layers</h3>
+      <label><input id="toggleLabels" type="checkbox" checked /> Commune labels</label>
+      <label><input id="togglePolygons" type="checkbox" checked /> Commune polygons</label>
+      <div class="style-group">
+        <label>Border <input id="borderColor" type="color" value="#228B22" /></label>
+        <label>Opacity <input id="borderOpacity" type="range" min="0" max="1" step="0.1" value="1" /></label>
+      </div>
+      <div class="style-group">
+        <label>Fill <input id="fillColor" type="color" value="#66BB66" /></label>
+        <label>Opacity <input id="fillOpacity" type="range" min="0" max="1" step="0.05" value="0.35" /></label>
+      </div>
+      <label>Basemap
+        <select id="baseMapSelect">
+          <option value="osm">OSM Default</option>
+          <option value="gmap">Google Map Default</option>
+          <option value="gsat">Google Satellite</option>
+          <option value="gter">Google Terrain</option>
+        </select>
+      </label>
+      <hr />
+      <button id="addPointBtn" type="button">Add Point</button>
+      <button id="exportPointsBtn" type="button">Export Points</button>
+    </div>
+  </div>
+
   <!-- Controls overlay -->
   <!--
     The controls panel hosts four coordinate input modes as well as locate/clear actions.


### PR DESCRIPTION
## Summary
- add a collapsible layer panel with style controls and basemap selection
- allow adding custom points and exporting them to GeoJSON
- implement Google base layer options
- document the new features

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888ca86f150832db18278aa0028aaa8

## Summary by Sourcery

Add interactive layer controls and custom point tools to the map application

New Features:
- Add collapsible layer panel to toggle commune labels and polygons and adjust border/fill styles
- Add basemap selector with OpenStreetMap and multiple Google tile layer options
- Enable adding custom point markers via map clicks and exporting them as a GeoJSON file
- Document new layer controls, basemap options, and point export features in README

Documentation:
- Update README to describe layer panel, style controls, basemap switching, and point export functionality